### PR TITLE
Add FastAPI backend scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ Todo en tiempo real y sin manos.
 git clone https://github.com/tu-user/taskwhisper.git
 cd taskwhisper
 docker compose up --build
+```
+
+## ▶️ Ejecutar backend localmente
+
+Instala las dependencias y lanza el servidor de desarrollo:
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.app.main:app --reload
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- scaffold FastAPI app with root `/` endpoint
- add backend requirements for FastAPI and Uvicorn
- document running backend locally with Uvicorn

## Testing
- `python -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6893be1cd4d08328b8bcce64499a1e2f