### PR TITLE
Add basic intent parser for appointments

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package."""

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for TaskWhisper backend."""

--- a/backend/app/intent_parser.py
+++ b/backend/app/intent_parser.py
@@ -1,0 +1,26 @@
+"""Simple intent parser for TaskWhisper."""
+
+from typing import Any, Dict
+
+# Keywords that trigger the CreateAppointment intent.
+CREATE_APPOINTMENT_KEYWORDS = {
+    "cita",
+    "appointment",
+    "reserva",
+    "agendar",
+    "schedule",
+}
+
+
+def parse_intent(text: str) -> Dict[str, Any]:
+    """Parse user input and extract a high level intent.
+
+    The parser performs a minimal keyword search to detect the
+    ``CreateAppointment`` intent. It returns a dictionary with two keys:
+    ``intent`` holding the detected intent name and ``params`` holding any
+    parameters (empty for now).
+    """
+    text_lower = text.lower()
+    if any(keyword in text_lower for keyword in CREATE_APPOINTMENT_KEYWORDS):
+        return {"intent": "CreateAppointment", "params": {}}
+    return {"intent": "Unknown", "params": {}}


### PR DESCRIPTION
## Summary
- add backend intent parser with keyword-based CreateAppointment detection
- scaffold backend package structure

## Testing
- `python -m pytest`
- `python - <<'PY'
from backend.app.intent_parser import parse_intent
print(parse_intent('Quiero agendar una cita con el doctor'))
print(parse_intent('Solo saludo'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6893be34d0a0832889f27299db668658