### PR TITLE
feat: scaffold backend app with docs and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
-      - name: Run tests
-        run: pytest
       - name: Lint with flake8
         run: flake8
+      - name: Run tests
+        run: pytest -W error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Gracias por considerar contribuir a TaskWhisper.
+
+## Branching model
+
+Este proyecto sigue un flujo *trunk-based* con dos ramas principales:
+
+- `main`: versión estable y lista para producción.
+- `dev`: rama de integración para nuevos cambios. Todas las pull requests deben apuntar aquí.
+
+## Commits
+
+Utilizamos [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) para mantener un historial claro.
+
+Ejemplos:
+- `feat: add intent parser`
+- `fix: handle empty input`
+- `docs: update architecture diagram`
+
+## Pull Requests
+
+1. Asegúrate de que `flake8` y `pytest` pasan sin errores.
+2. Actualiza la documentación cuando sea necesario.
+3. Describe claramente la motivación y los cambios en la PR.
+
+¡Feliz hacking!

--- a/README.md
+++ b/README.md
@@ -23,11 +23,69 @@ Todo en tiempo real y sin manos.
 | Mobile | React-Native (expo) |
 | Infra | Docker Compose + PostgreSQL |
 
-## 🚀 Quick start
+## 🏗️ Architecture
+
+```mermaid
+graph LR
+    mic((🎤 Mic)) --> whisper[Whisper STT]
+    whisper --> parser[parse_intent]
+    parser --> fastapi[FastAPI Actions]
+```
+
+- **Captura**: obtiene audio desde un micrófono o stream.
+- **STT**: Whisper transforma voz a texto.
+- **NLU**: `parse_intent` identifica la intención.
+- **Orquestador**: FastAPI ejecuta la acción correspondiente.
+
+## 🚀 Quick Start
+
+Clona el repositorio y crea un entorno virtual:
 
 ```bash
 git clone https://github.com/tu-user/taskwhisper.git
 cd taskwhisper
-docker compose up --build
+```
+
+### Linux / macOS
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+uvicorn backend.app.main:app --reload
+```
+
+### Windows
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\activate
+pip install -r backend/requirements.txt
+uvicorn backend.app.main:app --reload
+```
+
+La API estará disponible en `http://localhost:8000`.
+
+## 📡 Example
+
+### curl
+
+```bash
+curl http://localhost:8000/
+curl -X POST http://localhost:8000/parse_intent \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Necesito agendar una cita"}'
+```
+
+### Python `requests`
+
+```python
+import requests
+
+requests.get("http://localhost:8000/").json()
+requests.post(
+    "http://localhost:8000/parse_intent",
+    json={"text": "Necesito agendar una cita"},
+).json()
 ```
 

--- a/backend/app/intent_parser.py
+++ b/backend/app/intent_parser.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 CarlosIgRuz. MIT License.
+
 """Simple intent parser for TaskWhisper."""
 
 from typing import Any, Dict

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 CarlosIgRuz. MIT License.
+
+from fastapi import FastAPI
+from .intent_parser import parse_intent
+
+app = FastAPI()
+
+
+@app.get("/")
+async def health() -> dict:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/parse_intent")
+async def parse_intent_endpoint(payload: dict) -> dict:
+    """Parse text from the request body and return the detected intent."""
+    text = payload.get("text", "")
+    return parse_intent(text)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,6 @@
+fastapi
+httpx
+uvicorn
 flake8
 pytest
+pytest-asyncio

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 CarlosIgRuz. MIT License.
+
+import sys
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from backend.app.main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_health() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- document architecture, quick start, and API examples
- add FastAPI app with health and intent parsing endpoints
- add contributing guide, tests, and CI improvements

## Testing
- `flake8`
- `pytest -W error`


------
https://chatgpt.com/codex/tasks/task_e_689427b9b08c8328aacda9dc570da404